### PR TITLE
Update manifest.json to version 3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,17 @@
 {
     "name": "Gamepad to Keyboard Mapper",
     "version": "1.0.0",
-    "manifest_version": 2,
+    "manifest_version": 3,
     "description": "Map gamepad buttons and axes to keyboard keys",
     "homepage_url": "https://game103.net",
-    "browser_action": {
+    "action": {
         "default_title": "Gamepad to Keyboard Mapper",
         "default_popup": "popup.html"
     },
+    "host_permissions": [
+        "*://*/*"
+    ],
     "permissions": [
-        "*://*/*",
         "storage",
         "debugger"
     ],
@@ -19,13 +21,16 @@
                 "*://*/*"
             ],
             "js": ["content.js"],
-            "run_at": "document_end"
+            "run_at": "document_end",
+            "all_frames": true
         }
     ],
     "background": {
-        "scripts": ["background.js"]
+        "service_worker": "background.js"
     },
-    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+    "content_security_policy": {
+        "extension_pages": "script-src 'self'; object-src 'self'"
+    },
     "icons": {
         "16": "icon16.png",
         "48": "icon32.png",


### PR DESCRIPTION
Manifest version 2 is deprecated and version 3 is now required for extensions to run. I have tested this in latest chrome browser on both chrome os and windows. I've also added "all_frames" mode to allow iframe games compatibility.